### PR TITLE
simplify outputs checkbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,10 @@
                     <select id="metric"></select>
                 </span>
                 <span class="controlsGroup">
+                    <label for="simplify">Simplify Outputs</label>
+                    <input type="checkbox" id="simplify"></input>
+                </span>
+                <span class="controlsGroup">
                     <button id="computeButton" disabled="disabled">Compute</button>
                 </span>
             </div>

--- a/src/analyze/analyzer.js
+++ b/src/analyze/analyzer.js
@@ -192,6 +192,14 @@ Analyzer.prototype.analyze = function (costs, metricTitle) {
   this.visitor.start(this.IR, '');
 };
 
+// Simplify closed forms
+Analyzer.prototype.simplifyClosedForms = function () {
+  const cfm = this.abstractionToClosedFormMap;
+  for (var fn in cfm) {
+    cfm[fn] = math.simplify(cfm[fn]);
+  }
+};
+
 // Retrieves the symbolic result: this can be plotted or displayed
 Analyzer.prototype.symbolicOutput = function () {
   return new SymbolicOutput(this);

--- a/ui/events.js
+++ b/ui/events.js
@@ -1,8 +1,11 @@
 /* global carousels, carouselsPlot */
+let carouselsOutput;
+
 (function () {
   window.addEventListener('DOMContentLoaded', function () {
     const protocolSelect = document.getElementById('protocol');
     const metricSelect = document.getElementById('metric');
+    const simplifyCheckbox = document.getElementById('simplify')
     const computeButton = document.getElementById('computeButton');
     const textarea = document.getElementById('inputCode');
 
@@ -63,6 +66,7 @@
       yaxisSelect.appendChild(metricOption);
 
       // remove plot
+      carouselsOutput = output;
       carouselsPlot.purge();
     };
     // Showing errors
@@ -98,6 +102,7 @@
     computeButton.onclick = function () {
       const protocolValue = protocolSelect.value;
       const metricValue = metricSelect.value;
+      const simplifyBool = simplifyCheckbox.checked;
       const code = textarea.__codeMirrorInstance.getValue();
       const language = 'rust';
 
@@ -114,6 +119,7 @@
       // analyze code and display outputs
       try {
         analyzer.analyze(carousels.costs[protocolValue], metricValue);
+        if (simplifyBool) { analyzer.simplifyClosedForms(); }
         showOutput(analyzer.symbolicOutput());
       } catch (err) {
         showError(err);


### PR DESCRIPTION
Call math.simplify on the closed form outputs to trade-off analysis time with plotting time.

Unchecked: Analysis is < 1s, plotting n=100 for merge sort takes ~10s.
Box checked: Analysis is < 10s, plotting n=100 for merge sort takes ~1s.